### PR TITLE
fix(ci): publish pypi on workflow dispatch, test on PR ready to review

### DIFF
--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -1,8 +1,9 @@
 name: Build and release to PyPI
 
 on:
-    release:
-      types: [published]
+  # release:
+  #   types: [published]
+  workflow_dispatch:
 
 
 env:

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -1,8 +1,6 @@
 name: Build and release to PyPI
 
 on:
-  # release:
-  #   types: [published]
   workflow_dispatch:
 
 

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -56,7 +56,7 @@ jobs:
 
         steps:
             - name: Download Python artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v5
               with:
                   name: python-artifacts
                   path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oss-review-toolkit/ort-ci-github-action@v1
         with:
           allow-dynamic-versions: "true"
@@ -33,7 +33,7 @@ jobs:
       new_tag: ${{ steps.tagging.outputs.new_tag }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
     needs: versioning
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install GitHub CLI
         run: sudo apt-get install -y gh

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -6,7 +6,7 @@ name: Run tests for Python
 on:
   push:
   pull_request:
-
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -30,7 +30,7 @@ jobs:
       run: |
         hatch run +py=${{ matrix.python-version }} test:cov --doctest-modules --junitxml=junit/test-results.xml
     - name: SonarCloud Scan
-      uses: SonarSource/sonarqube-scan-action@v5.2.0
+      uses: SonarSource/sonarqube-scan-action@v5.3.1
       if: matrix.python-version == '3.10'
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Enable manual dispatch for PyPI releases and refine CI test triggers for pull requests

CI:
- Switch package publication workflow to manual dispatch instead of release events
- Restrict test-python workflow to run only on specific pull_request event types (opened, synchronize, reopened, ready_for_review)