### PR TITLE
Synchronize CI setup to organisation defaults

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow will install Python dependencies and run tests
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Run tests for Python
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
       run: |
         hatch run +py=${{ matrix.python-version }} test:cov --doctest-modules --junitxml=junit/test-results.xml
     - name: SonarCloud Scan
-      uses: SonarSource/sonarqube-scan-action@v5.3.1
+      uses: SonarSource/sonarqube-scan-action@v7.0.0
       if: matrix.python-version == '3.10'
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,6 @@
 sonar.projectKey=Health-RI_fairclient
 sonar.organization=health-ri
+sonar.sources=src/
+sonar.tests=tests/
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.10


### PR DESCRIPTION
## Summary by Sourcery

Align the Python test workflow and SonarQube configuration with updated organisation standards.

Build:
- Update GitHub Actions workflow to use the latest checkout and setup-python actions and restrict the Python test matrix to CPython versions only.

CI:
- Refresh SonarCloud scan GitHub Action version in the Python test workflow.

Chores:
- Configure SonarQube project to explicitly define source and test directories and keep project metadata in sync with organisation defaults.